### PR TITLE
chore(wiki):   add location support and sole proprietor field to agency and producer schemas

### DIFF
--- a/webhooks/examples/agency_example.json
+++ b/webhooks/examples/agency_example.json
@@ -14,7 +14,8 @@
     "name": "Premier Insurance Agency LLC",
     "phone": "555-987-6543",
     "status": "Active",
-    "website": "www.premierinsurance.com"
+    "website": "www.premierinsurance.com",
+    "is_sole_proprietor": false
   },
 
   "agency_address": [
@@ -113,5 +114,29 @@
     "name": "Agentero Insurance Organization",
     "external_id": "ext_org_456"
   },
-  "metadata_questions": "{\"agency_size\":\"small\",\"primary_market\":\"commercial\",\"years_in_business\":\"10\"}"
+  "metadata_questions": "{\"agency_size\":\"small\",\"primary_market\":\"commercial\",\"years_in_business\":\"10\"}",
+  "locations": [
+    {
+      "location_id": "loc_001",
+      "name": "Main Office",
+      "street": "123 Insurance Ave",
+      "city": "Chicago",
+      "state": "IL",
+      "zip": "60601",
+      "phone": "555-987-6543",
+      "email": "mainoffice@insuranceagency.com",
+      "is_primary": true
+    },
+    {
+      "location_id": "loc_002",
+      "name": "Branch Office",
+      "street": "456 Coverage Blvd",
+      "city": "Naperville",
+      "state": "IL",
+      "zip": "60540",
+      "phone": "555-123-9876",
+      "email": "branch@insuranceagency.com",
+      "is_primary": false
+    }
+  ]
 }

--- a/webhooks/examples/producer_example.json
+++ b/webhooks/examples/producer_example.json
@@ -22,7 +22,8 @@
     "phone": "415-555-0123",
     "state": "CA",
     "street": "123 Market Street",
-    "zip": "94105"
+    "zip": "94105",
+    "is_sole_proprietor": false
   },
   "producer_nipr_data": {
     "birth_date": "1980-01-15",
@@ -96,5 +97,29 @@
     "name": "ProducerFlow Organization",
     "external_id": "ext_org_789"
   },
-  "metadata_questions": "{\"years_experience\":\"15\",\"specializations\":\"life,health\",\"certification_level\":\"advanced\"}"
+  "metadata_questions": "{\"years_experience\":\"15\",\"specializations\":\"life,health\",\"certification_level\":\"advanced\"}",
+  "assigned_locations": [
+    {
+      "location_id": "loc_001",
+      "name": "Main Office",
+      "street": "123 Insurance Ave",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94105",
+      "phone": "415-555-0100",
+      "email": "mainoffice@insurance.com",
+      "is_primary": true
+    },
+    {
+      "location_id": "loc_002",
+      "name": "Downtown Branch",
+      "street": "789 Financial District",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94111",
+      "phone": "415-555-0200",
+      "email": "downtown@insurance.com",
+      "is_primary": false
+    }
+  ]
 }

--- a/webhooks/schema/agency_schema.json
+++ b/webhooks/schema/agency_schema.json
@@ -45,7 +45,8 @@
         "fax": { "type": "string" },
         "name": { "type": "string" },
         "phone": { "type": "string" },
-        "website": { "type": "string", "format": "uri" }
+        "website": { "type": "string", "format": "uri" },
+        "is_sole_proprietor": { "type": "boolean" }
       }
     },
     "agency_address": {
@@ -193,6 +194,24 @@
     "metadata_questions": {
       "type": "string",
       "description": "Custom metadata questions and answers associated with the agency"
+    },
+    "locations": {
+      "type": "array",
+      "description": "List of agency locations",
+      "items": {
+        "type": "object",
+        "properties": {
+          "location_id": { "type": "string" },
+          "name": { "type": "string" },
+          "street": { "type": "string" },
+          "city": { "type": "string" },
+          "state": { "type": "string" },
+          "zip": { "type": "string" },
+          "phone": { "type": "string" },
+          "email": { "type": "string", "format": "email" },
+          "is_primary": { "type": "boolean" }
+        }
+      }
     }
   },
   "required": ["id", "timestamp", "agency_id"],

--- a/webhooks/schema/producer_schema.json
+++ b/webhooks/schema/producer_schema.json
@@ -64,7 +64,8 @@
         "phone": { "type": "string" },
         "state": { "type": "string" },
         "street": { "type": "string" },
-        "zip": { "type": "string" }
+        "zip": { "type": "string" },
+        "is_sole_proprietor": { "type": "boolean" }
       }
     },
     "producer_nipr_data": {
@@ -172,6 +173,24 @@
     "metadata_questions": {
       "type": "string",
       "description": "Custom metadata questions and answers associated with the producer"
+    },
+    "assigned_locations": {
+      "type": "array",
+      "description": "List of locations assigned to the producer",
+      "items": {
+        "type": "object",
+        "properties": {
+          "location_id": { "type": "string" },
+          "name": { "type": "string" },
+          "street": { "type": "string" },
+          "city": { "type": "string" },
+          "state": { "type": "string" },
+          "zip": { "type": "string" },
+          "phone": { "type": "string" },
+          "email": { "type": "string", "format": "email" },
+          "is_primary": { "type": "boolean" }
+        }
+      }
     }
   },
   "required": ["id", "timestamp", "producer_id"],


### PR DESCRIPTION
Updates webhook schemas and examples to include new locations/assigned_locations arrays and is_sole_proprietor boolean field