### PR TITLE
chore: release v1.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.20] - 2026-03-05
+
+### Fixed
+
+#### ProducerService
+
+- **Biographic data missing in `GetAgencyAndProducers`** - `Producer.NIPR.Biographic` was always empty in `GetAgencyAndProducers` responses even when NIPR data existed
+  - `first_name`, `last_name`, `middle_name`, and `date_of_birth` are now correctly populated from NIPR for producers with an active NIPR sync status
+
+### Deprecated
+
+#### ProducerService
+
+- **`fein`, `company_name`, `state_domicile` in `Producer.NIPR.Biographic`** - These fields are deprecated and will always be empty
+  - Producers in ProducerFlow are always individual agents. NIPR does not return FEIN, company name, or state of domicile for individual agents — only for firm/agency entities.
+  - These fields were defined in the proto but never populated. They are now formally marked `deprecated = true` to make this explicit.
+  - No migration needed; the fields were always empty and their removal has no impact on existing integrations.
+
 ## [1.0.19] - 2026-02-19
 
 ### Added

--- a/gen/kotlin/gradle.properties
+++ b/gen/kotlin/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.19
+version=1.0.20
 
 kotlin.code.style=official
 

--- a/gen/ts/package-lock.json
+++ b/gen/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@producerflow/producerflowapi",
-  "version": "1.0.18",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@producerflow/producerflowapi",
-      "version": "1.0.18",
+      "version": "1.0.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "2.10.0"

--- a/gen/ts/package.json
+++ b/gen/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@producerflow/producerflowapi",
   "author": "Producerflow",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Generated TypeScript types for ProducerFlow API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- **Bug fix**: `Producer.NIPR.Biographic` was always empty in `GetAgencyAndProducers` responses — `first_name`, `last_name`, `middle_name`, `date_of_birth` are now correctly populated (mono PR #33363, PF-5946)
- **Deprecation**: `fein`, `company_name`, `state_domicile` in `Producer_NIPR_Biographic` marked `deprecated = true` — these were never populated since producers are always individual agents
- Version bumped `1.0.19 → 1.0.20` in `gen/ts/package.json` and `gen/kotlin/gradle.properties`