### PR TITLE
docs(changelog): fix v1.0.20 entry scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### ProducerService
 
-- **Biographic data missing in `GetAgencyAndProducers`** - `Producer.NIPR.Biographic` was always empty in `GetAgencyAndProducers` responses even when NIPR data existed
+- **Biographic data missing in `GetProducer` and `GetAgencyAndProducers`** - `Producer.NIPR.Biographic` was always empty in responses even when NIPR data existed
   - `first_name`, `last_name`, `middle_name`, and `date_of_birth` are now correctly populated from NIPR for producers with an active NIPR sync status
+- **`address_line_1` missing in `GetProducer` and `GetAgencyAndProducers`** - `Producer.Address.address_line_1` was not being mapped and always returned empty; it is now correctly populated
 
 ### Deprecated
 


### PR DESCRIPTION
Update v1.0.20 CHANGELOG entry to mention `GetProducer` (not just `GetAgencyAndProducers`) and the `address_line_1` fix that were also part of mono PR #33363.