### PR TITLE
chore: release v1.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.24] - 2026-05-29
+
+### Added
+
+#### AppointmentService
+
+- **`operational_status` filter on `ListAppointments`** — filter appointments by operational status (`OPERATIONAL_STATUS_ACTIVE`, `OPERATIONAL_STATUS_AT_RISK`); omit to return appointments regardless of operational status
+
+#### ProducerService
+
+- **New `ListProducerRoles` RPC** — returns the producer role labels configured for the authenticated tenant; use it to populate role pickers, validate role inputs, or detect whether the per-tenant producer-role feature is enabled (an empty list means no role should be sent)
+- **`role` field on `Producer`, `NewProducer`, and `UpdateProducerRequest`** — tenant-defined producer role label (e.g. "Licensed Producer", "CSR", "Agency Principal"). On create/update the value must match a role configured in the tenant's settings or the request is rejected with `INVALID_ARGUMENT`; on update, omit to preserve the existing role or send an empty string to clear it
+- **`regulatory_actions` list and `RegulatoryAction.state_code`** — producers can now expose multiple regulatory actions per state via the new repeated `regulatory_actions` field, each carrying its own `state_code`
+- Regenerated client libraries with latest proto changes
+
+### Deprecated
+
+#### ProducerService
+
+- **`CONTACT_ROLE_UNLICENSED_PRODUCER`** — requests carrying this value are still accepted for backward compatibility and stored as `CONTACT_ROLE_UNLICENSED_SERVICE`
+- **`regulatory_actions_by_state` map** — deprecated in favor of the new `regulatory_actions` list; the map carries only one action per state and is populated for backward compatibility only
+
 ## [1.0.23] - 2026-04-28
 
 ### Changed

--- a/gen/kotlin/gradle.properties
+++ b/gen/kotlin/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.23
+version=1.0.24
 
 kotlin.code.style=official
 

--- a/gen/ts/package-lock.json
+++ b/gen/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@producerflow/producerflowapi",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@producerflow/producerflowapi",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "2.12.0"

--- a/gen/ts/package.json
+++ b/gen/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@producerflow/producerflowapi",
   "author": "Producerflow",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Generated TypeScript types for ProducerFlow API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/wiki/Appointment-Operational-Status.md
+++ b/wiki/Appointment-Operational-Status.md
@@ -161,6 +161,7 @@ message ListAppointmentsRequest {
     string producer_id = 2;
     string agency_id = 3;
   }
+  repeated OperationalStatus operational_status = 4; // Optional filter
 }
 ```
 
@@ -343,7 +344,7 @@ A: Resolution depends on the specific risk reason:
 A: Operational status information is included when it's part of the change that triggered the webhook. Status-specific changes will always include the operational status details.
 
 **Q: Can I filter appointments by operational status via the API?**
-A: While there's no direct operational status filter in the current API, you can retrieve all appointments and filter by operational status in your application logic.
+A: Yes. `ListAppointments` accepts an optional `operational_status` filter. Pass one or more `OperationalStatus` values (e.g. `OPERATIONAL_STATUS_ACTIVE`, `OPERATIONAL_STATUS_AT_RISK`) to return only appointments in those operational states. Omit it to return appointments regardless of operational status.
 
 **Q: What's the difference between processing status and operational status?**
 A: Processing status relates to the appointment's lifecycle (in_progress, appointed, terminated, etc.), while operational status relates to ongoing compliance and business viability (active, at_risk).


### PR DESCRIPTION
Document operational_status filter on `ListAppointments`, new `ListProducerRoles` RPC, producer role field, and `regulatory_actions` list. Bump package versions and update wiki docs.