### PR TITLE
ci: use npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -62,9 +62,7 @@ jobs:
     - name: Publish to NPM
       run: |
         cd gen/ts
-        npm publish --provenance --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        npm publish --access public # Trusted Publishing (OIDC)
 
     - name: Get package version
       id: package-version


### PR DESCRIPTION
Replace the token-based authentication with OIDC trusted publishing for the npm publish step. Provenance is now generated automatically by trusted publishing, so the explicit --provenance flag and `NODE_AUTH_TOKEN` env var are removed.