### PR TITLE
docs(wiki): fix API workflow diagrams unreadable in dark mode

### DIFF
--- a/wiki/API-Workflows.md
+++ b/wiki/API-Workflows.md
@@ -321,7 +321,7 @@ sequenceDiagram
 
     Note over Client,WH: Manage Producer Location Assignments
     
-    rect rgb(200, 230, 250)
+    rect rgba(200, 230, 250, 0.1)
         Note right of Client: Assign Producer to Locations
         Client->>API: AssignProducerToLocations()
         Note over Client,API: producer_id + location_ids[]
@@ -342,7 +342,7 @@ sequenceDiagram
         end
     end
     
-    rect rgb(250, 230, 200)
+    rect rgba(250, 230, 200, 0.1)
         Note right of Client: Unassign Producer from Locations
         Client->>API: UnassignProducerFromLocations()
         Note over Client,API: producer_id + location_ids[]
@@ -370,7 +370,7 @@ sequenceDiagram
 
     Note over Client,System: Webhook Event Flow
     
-    rect rgb(200, 230, 250)
+    rect rgba(200, 230, 250, 0.1)
         Note right of API: Agency Events
         API->>WH: POST /webhook
         Note over WH: agency.created or<br/>agency.updated
@@ -379,7 +379,7 @@ sequenceDiagram
         WH-->>API: 200 OK
     end
     
-    rect rgb(250, 230, 200)
+    rect rgba(250, 230, 200, 0.1)
         Note right of API: Producer Events
         API->>WH: POST /webhook
         Note over WH: producer.created or<br/>producer.updated
@@ -388,7 +388,7 @@ sequenceDiagram
         WH-->>API: 200 OK
     end
     
-    rect rgb(230, 250, 230)
+    rect rgba(230, 250, 230, 0.1)
         Note right of API: Location Events
         API->>WH: POST /webhook
         Note over WH: Included in agency.updated<br/>for location changes
@@ -397,7 +397,7 @@ sequenceDiagram
         WH-->>API: 200 OK
     end
     
-    rect rgb(250, 220, 250)
+    rect rgba(250, 220, 250, 0.1)
         Note right of API: Appointment Events
         API->>WH: POST /webhook
         Note over WH: appointment.created or<br/>appointment.updated

--- a/wiki/Webhooks.md
+++ b/wiki/Webhooks.md
@@ -112,14 +112,14 @@ sequenceDiagram
     PF->>PF: Create Agency Record
     PF->>PF: Create Principal Producer Record
     
-    rect rgb(200, 230, 250)
+    rect rgba(200, 230, 250, 0.1)
         Note right of PF: Event 1: Agency Created
         PF->>WH: POST /webhook
         Note over WH: agency.created event
         WH-->>PF: 200 OK
     end
     
-    rect rgb(250, 230, 200)
+    rect rgba(250, 230, 200, 0.1)
         Note right of PF: Event 2: Producer Created
         PF->>WH: POST /webhook
         Note over WH: producer.created event


### PR DESCRIPTION
## Problem

The Mermaid sequence diagrams in **API-Workflows** and **Webhooks** are hard to read in dark mode. Section bands (Agency Events, Producer Events, Location Events, Appointment Events, onboarding events) use opaque light pastel fills via `rect rgb(...)`. GitHub renders Mermaid theme-aware, so in dark mode the message labels (`POST /webhook`, `Verify signature`, `200 OK`, `Process agency data`, …) are drawn in light text while the band stays bright pastel, leaving the text washed-out and unreadable.

Now:

<img width="448" height="625" alt="image" src="https://github.com/user-attachments/assets/42267c7c-4ff1-4f8a-af6b-35eeb59fc406" />


Linear: PF-6926