### PR TITLE
chore: release v1.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.26] - 2026-07-14
+
+### Added
+
+#### AppointmentService
+
+- **New `RISK_REASON_STATE_APPOINTMENT_TERMINATED` on `RiskReason`** — a state has terminated the appointment (reported via NIPR) while ProducerFlow still shows it as active
+- **New `RISK_REASON_REGULATORY_ACTION` on `RiskReason`** — an undismissed regulatory action exists (reported via NIPR) against the appointment's producer or agency in the appointment's state
+
+#### ProducerService
+
+- **`organization` field on `Producer`** — the organization that the producer's agency belongs to, with full details (id, name, and contact information); unset when the producer's agency does not belong to any organization
+
+#### TestingService (DEV and UAT only)
+
+- **New `TestingService`** — cleanup utilities that let tenants reset their test environments between automated runs. Every method is enabled exclusively in dev and UAT; in production every call is rejected with `PERMISSION_DENIED`
+- **New `DeleteAgency` RPC** — permanently removes an agency and every producer, appointment, and NIPR record scoped to it, freeing the underlying licenses to be appointed again
+- **New `DeleteAppointment` RPC** — permanently removes a single appointment, freeing the underlying license to be appointed again (unlike termination, which leaves a record that still blocks re-appointment)
+
+### Changed
+
+- Regenerated client libraries with latest proto changes
+
 ## [1.0.25] - 2026-06-15
 
 ### Added

--- a/gen/kotlin/gradle.properties
+++ b/gen/kotlin/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.25
+version=1.0.26
 
 kotlin.code.style=official
 

--- a/gen/ts/package-lock.json
+++ b/gen/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@producerflow/producerflowapi",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@producerflow/producerflowapi",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "2.12.0"

--- a/gen/ts/package.json
+++ b/gen/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@producerflow/producerflowapi",
   "author": "Producerflow",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Generated TypeScript types for ProducerFlow API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Prepares the **1.0.26** release of the ProducerFlow API client libraries.

- Bump TypeScript package (`gen/ts/package.json` + `package-lock.json`) to `1.0.26`
- Bump Kotlin package (`gen/kotlin/gradle.properties`) to `1.0.26`
- Add `## [1.0.26]` section to `CHANGELOG.md`

## Changes since 1.0.25 (all additive)

### AppointmentService
- New `RISK_REASON_STATE_APPOINTMENT_TERMINATED` on `RiskReason` — a state has terminated the appointment (via NIPR) while ProducerFlow still shows it active
- New `RISK_REASON_REGULATORY_ACTION` on `RiskReason` — undismissed regulatory action against the producer or agency in the appointment's state

### ProducerService
- New `organization` field on `Producer` — the organization the producer's agency belongs to; unset when there is none

### TestingService (DEV and UAT only)
- New `TestingService` — cleanup utilities to reset test environments; rejected with `PERMISSION_DENIED` in production
- New `DeleteAgency` and `DeleteAppointment` RPCs — free the underlying licenses for reuse across automated test runs

## After merge
1. Create a GitHub release with tag `v1.0.26`
2. Manually trigger the publish workflows:
   - Publish to NPM (`.github/workflows/npm-publish.yml`)
   - Publish Kotlin to GitHub Packages (`.github/workflows/kotlin-publish.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)