### PR TITLE
chore: release v1.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.28] - 2026-08-07
+
+### Added
+
+#### ProducerService
+
+- **`agency` on `Contact`** — basic details of the agency the contact belongs to (`agency_id`, `name`, and the tenant-provided `external_id`), so callers no longer need a follow-up `GetAgency` to map a contact to their own agency identifier. Returned by every RPC that returns a `Contact`, including `GetContact` and `ListAgencyContacts`
+- **`organization` on `Contact`** — the organization that the contact's agency belongs to, with full details (id, name, and contact information). Unset when the agency does not belong to any organization. Together with `agency`, this resolves a contact to its partner/source organization in a single call
+- **New `AgencyAlreadyExistsErrorDetail`** — when `NewAgency` fails with `ALREADY_EXISTS`, the error now carries the identifiers of the conflicting agency (`agency_id`, `external_id`, `npn`, `organization_id`), so the existing record can be linked without a follow-up lookup. It identifies the agency holding the conflicting agency email or NPN; for a principal email conflict, the agency of the existing producer; and for a sole-proprietor NPN conflict, the existing sole-proprietor agency registered under the principal's NPN. The detail travels in the error's details list as a `google.protobuf.Any` and is provided on a best-effort basis, so handle its absence gracefully
+
+### Changed
+
+- Regenerated client libraries with latest proto changes
+
+---
+
 ## [1.0.27] - 2026-07-21
 
 ### Added

--- a/gen/kotlin/gradle.properties
+++ b/gen/kotlin/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.27
+version=1.0.28
 
 kotlin.code.style=official
 

--- a/gen/ts/package-lock.json
+++ b/gen/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@producerflow/producerflowapi",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@producerflow/producerflowapi",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "2.12.0"

--- a/gen/ts/package.json
+++ b/gen/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@producerflow/producerflowapi",
   "author": "Producerflow",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "Generated TypeScript types for ProducerFlow API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## ProducerService

- **`agency` on `Contact`**. Basic details of the agency the contact belongs to (`agency_id`, `name`, and the tenant-provided `external_id`), removing the follow-up `GetAgency` call that mapping a contact to your own agency identifier used to need. Returned by every RPC that returns a `Contact`, including `GetContact` and `ListAgencyContacts`
- **`organization` on `Contact`**. The organization the contact's agency belongs to, with full details (id, name, contact information). Unset when the agency belongs to no organization. Together with `agency` this resolves a contact to its partner/source organization in a single call
- **New `AgencyAlreadyExistsErrorDetail`**. `NewAgency` failures with `ALREADY_EXISTS` now carry the identifiers of the conflicting agency (`agency_id`, `external_id`, `npn`, `organization_id`) so the existing record can be linked without a follow-up lookup. Covers agency email/NPN conflicts, principal email conflicts (returning the existing producer's agency), and sole-proprietor NPN conflicts. Delivered as a `google.protobuf.Any` in the error details on a best-effort basis
