### PR TITLE
docs: include external_agency_id in contact webhook events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### Webhooks
+
+- **`external_agency_id` in contact webhook events** — `contact.created`, `contact.updated`, and `contact.deleted` payloads now include the external ID of the contact's agency, matching producer and appointment events. Omitted when the agency has no external ID assigned. Added to the contact schema and example payload
+
 ## [1.0.28] - 2026-08-07
 
 ### Added

--- a/webhooks/examples/contact_example.json
+++ b/webhooks/examples/contact_example.json
@@ -4,6 +4,7 @@
   "origin": "ProducerFlowAPI",
   "timestamp": "2024-01-20T15:30:45Z",
   "agency_id": "agc_987654321",
+  "external_agency_id": "ext_agc_654987321",
   "contact_id": "cnt_456789123",
   "first_name": "John",
   "last_name": "Doe",

--- a/webhooks/schema/contact_schema.json
+++ b/webhooks/schema/contact_schema.json
@@ -28,6 +28,10 @@
       "type": "string",
       "description": "Always present. ID of the agency that the contact belongs to"
     },
+    "external_agency_id": {
+      "type": "string",
+      "description": "Only present if filled in by tenant. External ID of the agency that the contact belongs to"
+    },
     "contact_id": {
       "type": "string",
       "minLength": 1,

--- a/wiki/Webhooks.md
+++ b/wiki/Webhooks.md
@@ -321,7 +321,7 @@ Each webhook type has specific required fields:
 #### Identifier Fields
 
 - **Agency Identifier**: All webhook types include `agency_id`. For agency webhooks, this identifies the agency itself. For producer and contact webhooks, this identifies the associated agency.
-- **External Identifiers**: When available, webhooks include `external_id` fields representing identifiers from your system that you've provided to ProducerFlow.
+- **External Identifiers**: When available, webhooks include `external_id` fields representing identifiers from your system that you've provided to ProducerFlow. Producer and contact webhooks also include `external_agency_id`, the external ID of the associated agency.
 - **National Producer Numbers (NPN)**: Included when available for agencies and producers.
 
 #### Origin Field Values
@@ -361,7 +361,7 @@ For update events, only the changed section(s) will be included:
 
 #### Contact Data
 
-Contact webhooks contain flattened data including personal information, role, and address details.
+Contact webhooks contain flattened data including personal information, role, and address details. They also include `external_agency_id`, the external ID of the contact's agency, when the agency has one.
 
 ### Schema Validation
 

--- a/wiki/Webhooks.md
+++ b/wiki/Webhooks.md
@@ -321,7 +321,7 @@ Each webhook type has specific required fields:
 #### Identifier Fields
 
 - **Agency Identifier**: All webhook types include `agency_id`. For agency webhooks, this identifies the agency itself. For producer and contact webhooks, this identifies the associated agency.
-- **External Identifiers**: When available, webhooks include `external_id` fields representing identifiers from your system that you've provided to ProducerFlow. Producer and contact webhooks also include `external_agency_id`, the external ID of the associated agency.
+- **External Identifiers**: When available, webhooks include `external_id` fields representing identifiers from your system that you've provided to ProducerFlow.
 - **National Producer Numbers (NPN)**: Included when available for agencies and producers.
 
 #### Origin Field Values
@@ -361,7 +361,7 @@ For update events, only the changed section(s) will be included:
 
 #### Contact Data
 
-Contact webhooks contain flattened data including personal information, role, and address details. They also include `external_agency_id`, the external ID of the contact's agency, when the agency has one.
+Contact webhooks contain flattened data including personal information, role, and address details.
 
 ### Schema Validation
 


### PR DESCRIPTION
Contact webhook events (contact.created, contact.updated, contact.deleted) now carry external_agency_id, the external ID of the agency the contact belongs to, matching producer and appointment events. This adds the field to the contact schema and to the example payload, keeping these copies in sync with the canonical files in the monorepo. The field is additive and optional: it is omitted when the agency has no external ID assigned.